### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
     - name: Run actionlint

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.label.name == 'auto-merge'
     steps:
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}

--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
           private-key: ${{ secrets.PR_AUTO_MERGER_PRIVATE_KEY }}
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Add auto-merge label

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,11 +20,11 @@ jobs:
           - '4.0'
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1.308.0
+      uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true

--- a/.github/workflows/rbs_collection.yml
+++ b/.github/workflows/rbs_collection.yml
@@ -10,23 +10,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/create-github-app-token@v3.2.0
+    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: app-token
       with:
         app-id: ${{ vars.REPO_HOUSEKEEPER_APP_ID }}
         private-key: ${{ secrets.REPO_HOUSEKEEPER_PRIVATE_KEY }}
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1.308.0
+      uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
       with:
         ruby-version: ruby
         bundler-cache: true
     - name: Update rbs collection
       run: bundle exec rbs collection update
     - name: Create a pull request
-      uses: peter-evans/create-pull-request@v8
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
       with:
         add-paths: rbs_collection.lock.yaml
         commit-message: 'rbs: Update RBS collection'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,13 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1.308.0
+        uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0
         with:
           ruby-version: ruby
           bundler-cache: true
       - name: Publish to RubyGems
-        uses: rubygems/release-gem@v1
+        uses: rubygems/release-gem@f0d7faff26625599a847d40d9fa28ace24c2aacc # v1


### PR DESCRIPTION
## Summary

Pin every third-party `uses:` reference in `.github/workflows/*.yml` to a commit SHA, with the original tag preserved as a trailing comment.

This is the standard mitigation against tag mutability — a tag like `@v3` can be force-moved to point at a different commit (intentionally or via repo compromise), and any workflow consuming that tag would silently execute the new code. Pinning to a SHA removes that surface; Dependabot still tracks the tag comment to file version-bump PRs.

This is the first of a series of `zizmor` findings to address; SHA pinning resolves the `unpinned-uses` audit.

## Test plan

- [x] `actionlint` passes
- [ ] CI still runs to completion on this PR