### PR TITLE
Add RBS type annotations using rbs-inline

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 AllCops:
   TargetRubyVersion: 3.2
 
+Layout/LeadingCommentSpace:
+  AllowRBSInlineAnnotation: true
+
 Style/Documentation:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "rake", "~> 13.4"
 gem "rubocop", "~> 1.88"
 
 group :development do
+  gem "rbs-inline", require: false
   gem "rspec", require: false
   gem "rspec-daemon", require: false
   gem "steep", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,9 @@ GEM
       logger
       prism (>= 1.6.0)
       tsort
+    rbs-inline (0.14.0)
+      prism (>= 0.29)
+      rbs (~> 4.0)
     regexp_parser (2.12.0)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
@@ -127,6 +130,7 @@ PLATFORMS
 
 DEPENDENCIES
   rake (~> 13.4)
+  rbs-inline
   rbs_config!
   rspec
   rspec-daemon

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,11 @@ namespace :rbs do
     sh "bundle exec rbs collection install --frozen"
   end
 
+  desc "Generate RBS files"
+  task :generate do
+    sh "rbs-inline", "--opt-out", "--output=sig", "lib"
+  end
+
   desc "Validate RBS files"
   task validate: "rbs:install" do
     sh "bundle exec rbs -Isig validate"

--- a/lib/rbs_config/config.rb
+++ b/lib/rbs_config/config.rb
@@ -5,19 +5,24 @@ require "active_support/core_ext/string/inflections"
 
 module RbsConfig
   module Config
-    def self.generate(files:, class_name: "Settings")
+    # @rbs files: Array[Pathname]
+    # @rbs class_name: String
+    def self.generate(files:, class_name: "Settings") #: String
       Generator.new(class_name: class_name, files: files).generate
     end
 
     class Generator
-      attr_reader :class_name, :files
+      attr_reader :class_name #: String
+      attr_reader :files #: Array[Pathname]
 
-      def initialize(class_name:, files:)
+      # @rbs class_name: String
+      # @rbs files: Array[Pathname]
+      def initialize(class_name:, files:) #: void
         @class_name = class_name
         @files = files
       end
 
-      def generate
+      def generate #: String
         config = load_config(files)
         classes = generate_classes(config)
         methods = generate_methods(config)
@@ -38,14 +43,16 @@ module RbsConfig
 
       private
 
-      def format(rbs)
+      # @rbs rbs: String
+      def format(rbs) #: String
         parsed = RBS::Parser.parse_signature(rbs)
         StringIO.new.tap do |out|
           RBS::Writer.new(out: out).write(parsed[1] + parsed[2])
         end.string
       end
 
-      def generate_classes(config)
+      # @rbs config: Hash[untyped, untyped]
+      def generate_classes(config) #: Array[String]
         config.filter_map do |key, value|
           case value
           when Array
@@ -64,13 +71,16 @@ module RbsConfig
         end
       end
 
-      def generate_methods(config)
+      # @rbs config: Hash[untyped, untyped]
+      def generate_methods(config) #: Array[String]
         config.map do |key, value|
           "def #{key}: () -> #{stringify_type(key, value)}"
         end
       end
 
-      def stringify_type(name, value)
+      # @rbs name: untyped
+      # @rbs value: untyped
+      def stringify_type(name, value) #: String
         case value
         when Hash
           name.camelize
@@ -86,7 +96,8 @@ module RbsConfig
         end
       end
 
-      def load_config(files)
+      # @rbs files: Array[Pathname]
+      def load_config(files) #: Hash[untyped, untyped]
         configs = files.map do |f|
           content = ERB.new(f.read).result
           YAML.unsafe_load(content)

--- a/lib/rbs_config/rails_config.rb
+++ b/lib/rbs_config/rails_config.rb
@@ -6,18 +6,20 @@ require "active_support/core_ext/string/inflections"
 
 module RbsConfig
   module RailsConfig
-    def self.generate(mapping:)
+    # @rbs mapping: Hash[untyped, Hash[untyped, untyped] | ActiveSupport::OrderedOptions]
+    def self.generate(mapping:) #: String
       Generator.new(mapping: mapping).generate
     end
 
     class Generator
-      attr_reader :mapping
+      attr_reader :mapping #: Hash[untyped, Hash[untyped, untyped] | ActiveSupport::OrderedOptions]
 
-      def initialize(mapping:)
+      # @rbs mapping: Hash[untyped, Hash[untyped, untyped] | ActiveSupport::OrderedOptions]
+      def initialize(mapping:) #: void
         @mapping = mapping
       end
 
-      def generate
+      def generate #: String
         classes = generate_classes(mapping)
         methods = mapping.map do |key, value|
           "def #{key}: () -> #{stringify_type(key, value)}"
@@ -39,14 +41,16 @@ module RbsConfig
 
       private
 
-      def format(rbs)
+      # @rbs rbs: String
+      def format(rbs) #: String
         parsed = RBS::Parser.parse_signature(rbs)
         StringIO.new.tap do |out|
           RBS::Writer.new(out: out).write(parsed[1] + parsed[2])
         end.string
       end
 
-      def generate_classes(config)
+      # @rbs config: Hash[untyped, untyped] | ActiveSupport::OrderedOptions
+      def generate_classes(config) #: Array[String]
         config.filter_map do |key, value|
           next unless value.is_a?(ActiveSupport::OrderedOptions)
 
@@ -62,7 +66,8 @@ module RbsConfig
         end
       end
 
-      def generate_methods(config)
+      # @rbs config: Hash[untyped, untyped] | ActiveSupport::OrderedOptions
+      def generate_methods(config) #: Array[String]
         case config
         when ActiveSupport::OrderedOptions
           generate_ordered_options_methods(config)
@@ -71,7 +76,8 @@ module RbsConfig
         end
       end
 
-      def generate_ordered_options_methods(config)
+      # @rbs config: ActiveSupport::OrderedOptions
+      def generate_ordered_options_methods(config) #: Array[String]
         methods = config.map do |key, value|
           type = stringify_type(key, value)
           <<~RBS
@@ -87,14 +93,17 @@ module RbsConfig
         methods + ["def []: #{brace_method_type}"]
       end
 
-      def generate_hash_methods(config)
+      # @rbs config: Hash[untyped, untyped]
+      def generate_hash_methods(config) #: Array[String]
         method_type = config.map do |key, value|
           "(:#{key} | \"#{key}\") -> #{stringify_type(key, value)}"
         end.join(" | ")
         ["def []: #{method_type}"]
       end
 
-      def stringify_type(name, value) # rubocop:disable Metrics/CyclomaticComplexity
+      # @rbs name: untyped
+      # @rbs value: untyped
+      def stringify_type(name, value) #: String # rubocop:disable Metrics/CyclomaticComplexity
         case value
         when ActiveSupport::OrderedOptions
           name.to_s.camelize

--- a/lib/rbs_config/rake_task.rb
+++ b/lib/rbs_config/rake_task.rb
@@ -5,9 +5,16 @@ require "rake/tasklib"
 
 module RbsConfig
   class RakeTask < Rake::TaskLib
-    attr_accessor :type, :class_name, :files, :mapping, :name, :signature_root_dir
+    attr_accessor :type #: :config | :rails
+    attr_accessor :class_name #: String
+    attr_accessor :files #: Array[Pathname]
+    attr_accessor :mapping #: Hash[untyped, Hash[untyped, untyped]]
+    attr_accessor :name #: Symbol
+    attr_accessor :signature_root_dir #: Pathname
 
-    def initialize(name = :'rbs:config', &block)
+    # @rbs name: Symbol
+    # @rbs &block: ?(RbsConfig::RakeTask) -> void
+    def initialize(name = :'rbs:config', &block) #: void
       super()
 
       @name = name
@@ -26,14 +33,14 @@ module RbsConfig
       define_setup_task
     end
 
-    def define_setup_task
+    def define_setup_task #: void
       desc "Run all tasks of rbs_config"
 
       deps = [:"#{name}:clean", :"#{name}:generate"]
       task("#{name}:setup" => deps)
     end
 
-    def define_generate_task
+    def define_generate_task #: void
       desc "Generate RBS files for config gem"
       task "#{name}:generate" do
         require "rbs_config" # load RbsConfig lazily
@@ -50,7 +57,7 @@ module RbsConfig
       end
     end
 
-    def define_clean_task
+    def define_clean_task #: void
       desc "Clean RBS files for config gem"
       task "#{name}:clean" do
         signature_root_dir.rmtree if signature_root_dir.exist?

--- a/sig/generators/rbs_config/install_generator.rbs
+++ b/sig/generators/rbs_config/install_generator.rbs
@@ -1,0 +1,7 @@
+# Generated from lib/generators/rbs_config/install_generator.rb with RBS::Inline
+
+module RbsConfig
+  class InstallGenerator < Rails::Generators::Base
+    def create_raketask: () -> untyped
+  end
+end

--- a/sig/rbs_config.rbs
+++ b/sig/rbs_config.rbs
@@ -1,4 +1,6 @@
+# Generated from lib/rbs_config.rb with RBS::Inline
+
 module RbsConfig
-  VERSION: String
-  # See the writing guide of rbs: https://github.com/ruby/rbs#guides
+  class Error < StandardError
+  end
 end

--- a/sig/rbs_config/config.rbs
+++ b/sig/rbs_config/config.rbs
@@ -1,20 +1,38 @@
+# Generated from lib/rbs_config/config.rb with RBS::Inline
+
 module RbsConfig
   module Config
+    # @rbs files: Array[Pathname]
+    # @rbs class_name: String
     def self.generate: (files: Array[Pathname], ?class_name: String) -> String
 
     class Generator
       attr_reader class_name: String
+
       attr_reader files: Array[Pathname]
 
+      # @rbs class_name: String
+      # @rbs files: Array[Pathname]
       def initialize: (class_name: String, files: Array[Pathname]) -> void
+
       def generate: () -> String
 
       private
 
+      # @rbs rbs: String
       def format: (String rbs) -> String
+
+      # @rbs config: Hash[untyped, untyped]
       def generate_classes: (Hash[untyped, untyped] config) -> Array[String]
+
+      # @rbs config: Hash[untyped, untyped]
       def generate_methods: (Hash[untyped, untyped] config) -> Array[String]
-      def stringify_type: (untyped type, untyped value) -> String
+
+      # @rbs name: untyped
+      # @rbs value: untyped
+      def stringify_type: (untyped name, untyped value) -> String
+
+      # @rbs files: Array[Pathname]
       def load_config: (Array[Pathname] files) -> Hash[untyped, untyped]
     end
   end

--- a/sig/rbs_config/rails_config.rbs
+++ b/sig/rbs_config/rails_config.rbs
@@ -1,20 +1,37 @@
+# Generated from lib/rbs_config/rails_config.rb with RBS::Inline
+
 module RbsConfig
   module RailsConfig
+    # @rbs mapping: Hash[untyped, Hash[untyped, untyped] | ActiveSupport::OrderedOptions]
     def self.generate: (mapping: Hash[untyped, Hash[untyped, untyped] | ActiveSupport::OrderedOptions]) -> String
 
     class Generator
       attr_reader mapping: Hash[untyped, Hash[untyped, untyped] | ActiveSupport::OrderedOptions]
 
+      # @rbs mapping: Hash[untyped, Hash[untyped, untyped] | ActiveSupport::OrderedOptions]
       def initialize: (mapping: Hash[untyped, Hash[untyped, untyped] | ActiveSupport::OrderedOptions]) -> void
+
       def generate: () -> String
 
       private
 
+      # @rbs rbs: String
       def format: (String rbs) -> String
+
+      # @rbs config: Hash[untyped, untyped] | ActiveSupport::OrderedOptions
       def generate_classes: (Hash[untyped, untyped] | ActiveSupport::OrderedOptions config) -> Array[String]
-      def generate_methods: (Hash[untyped, untyped] | ActiveSupport::OrderedOptions config) -> Array[string]
-      def generate_ordered_options_methods: (ActiveSupport::OrderedOptions config) -> Array[string]
-      def generate_hash_methods: (Hash[untyped, untyped]) -> Array[string]
+
+      # @rbs config: Hash[untyped, untyped] | ActiveSupport::OrderedOptions
+      def generate_methods: (Hash[untyped, untyped] | ActiveSupport::OrderedOptions config) -> Array[String]
+
+      # @rbs config: ActiveSupport::OrderedOptions
+      def generate_ordered_options_methods: (ActiveSupport::OrderedOptions config) -> Array[String]
+
+      # @rbs config: Hash[untyped, untyped]
+      def generate_hash_methods: (Hash[untyped, untyped] config) -> Array[String]
+
+      # @rbs name: untyped
+      # @rbs value: untyped
       def stringify_type: (untyped name, untyped value) -> String
     end
   end

--- a/sig/rbs_config/rake_task.rbs
+++ b/sig/rbs_config/rake_task.rbs
@@ -1,16 +1,27 @@
+# Generated from lib/rbs_config/rake_task.rb with RBS::Inline
+
 module RbsConfig
   class RakeTask < Rake::TaskLib
     attr_accessor type: :config | :rails
+
     attr_accessor class_name: String
+
     attr_accessor files: Array[Pathname]
-    attr_accessor name: Symbol
+
     attr_accessor mapping: Hash[untyped, Hash[untyped, untyped]]
+
+    attr_accessor name: Symbol
+
     attr_accessor signature_root_dir: Pathname
 
-    def initialize: (?Symbol name) ? { (RbsConfig::RakeTask) -> void } -> void
+    # @rbs name: Symbol
+    # @rbs &block: ?(RbsConfig::RakeTask) -> void
+    def initialize: (?Symbol name) ?{ (RbsConfig::RakeTask) -> void } -> void
 
     def define_setup_task: () -> void
+
     def define_generate_task: () -> void
+
     def define_clean_task: () -> void
   end
 end

--- a/sig/rbs_config/version.rbs
+++ b/sig/rbs_config/version.rbs
@@ -1,0 +1,5 @@
+# Generated from lib/rbs_config/version.rb with RBS::Inline
+
+module RbsConfig
+  VERSION: ::String
+end


### PR DESCRIPTION
## Summary
This PR adds comprehensive RBS (Ruby Signature) type annotations to the codebase using the `rbs-inline` gem. The annotations are embedded directly in the source code as comments and automatically generated into `.rbs` signature files.

## Key Changes
- **Added inline RBS annotations** to all source files in `lib/` using the `#:` comment syntax
- **Generated signature files** from inline annotations:
  - `sig/rbs_config/config.rbs` - Config module signatures
  - `sig/rbs_config/rails_config.rbs` - RailsConfig module signatures
  - `sig/rbs_config/rake_task.rbs` - RakeTask class signatures
  - `sig/rbs_config/version.rbs` - Version constant signature
  - `sig/generators/rbs_config/install_generator.rbs` - InstallGenerator signatures
- **Updated `sig/rbs_config.rbs`** to define the `Error` class and reference the version module
- **Added `rbs-inline` gem** to development dependencies
- **Added Rake task** to generate RBS files from inline annotations
- **Updated RuboCop configuration** to allow RBS inline annotations in leading comments

## Notable Implementation Details
- All method signatures include parameter and return types
- Fixed type inconsistencies (e.g., `Array[string]` → `Array[String]`)
- Separated multi-attribute `attr_accessor` declarations for clarity in signatures
- Added documentation header comments to generated `.rbs` files indicating they are auto-generated
- The generation process is now part of the development workflow via `rake rbs:generate`

https://claude.ai/code/session_01SMESK8C88BGGVHo2J6FpDe