### PR TITLE
Introduce rubocop-numbered-params

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 AllCops:
   TargetRubyVersion: 3.2
 
+plugins:
+  - rubocop-numbered-params
+
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 gem "rake", "~> 13.4"
 
 gem "rubocop", "~> 1.88"
+gem "rubocop-numbered-params"
 
 group :development do
   gem "rbs-inline", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
     csv (3.3.5)
     diff-lcs (1.6.2)
     drb (2.2.3)
+    ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     fileutils (1.8.0)
@@ -93,6 +94,9 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
+    rubocop-numbered-params (1.0.0)
+      lint_roller (~> 1.0)
+      rubocop (>= 1.72.1)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     steep (2.0.0)
@@ -123,6 +127,7 @@ GEM
     uri (1.1.1)
 
 PLATFORMS
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-darwin-23
   x86_64-darwin-24
@@ -135,6 +140,7 @@ DEPENDENCIES
   rspec
   rspec-daemon
   rubocop (~> 1.88)
+  rubocop-numbered-params
   steep
 
 BUNDLED WITH

--- a/lib/rbs_config/config.rb
+++ b/lib/rbs_config/config.rb
@@ -85,7 +85,7 @@ module RbsConfig
         when Hash
           name.camelize
         when Array
-          types = value.map { |v| stringify_type(name, v) }.uniq
+          types = value.map { stringify_type(name, _1) }.uniq
           "Array[#{types.join(" | ")}]"
         when NilClass
           "nil"

--- a/lib/rbs_config/rails_config.rb
+++ b/lib/rbs_config/rails_config.rb
@@ -103,7 +103,7 @@ module RbsConfig
 
       # @rbs name: untyped
       # @rbs value: untyped
-      def stringify_type(name, value) #: String # rubocop:disable Metrics/CyclomaticComplexity
+      def stringify_type(name, value) #: String
         case value
         when ActiveSupport::OrderedOptions
           name.to_s.camelize
@@ -113,7 +113,7 @@ module RbsConfig
           end
           "{ #{pairs.join(", ")} }"
         when Array
-          types = value.map { |v| stringify_type(name, v) }.uniq
+          types = value.map { stringify_type(name, _1) }.uniq
           "Array[#{types.join(" | ")}]"
         when NilClass
           "nil"

--- a/rbs_config.gemspec
+++ b/rbs_config.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     end
   end
   spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.executables = spec.files.grep(%r{\Aexe/}) { File.basename(_1) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport"


### PR DESCRIPTION
Add the `rubocop-numbered-params` plugin to enforce a consistent style for numbered block parameters, matching the setup already used in other repositories.

- Add `rubocop-numbered-params` to the Gemfile and Gemfile.lock
- Register the plugin in `.rubocop.yml`
- Autocorrect existing offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)