### PR TITLE
Introduce rubocop-rake plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
 
 plugins:
   - rubocop-numbered-params
+  - rubocop-rake
 
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "rake", "~> 13.4"
 
 gem "rubocop", "~> 1.88"
 gem "rubocop-numbered-params"
+gem "rubocop-rake"
 
 group :development do
   gem "rbs-inline", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,9 @@ GEM
     rubocop-numbered-params (1.0.0)
       lint_roller (~> 1.0)
       rubocop (>= 1.72.1)
+    rubocop-rake (0.7.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72.1)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     steep (2.0.0)
@@ -141,6 +144,7 @@ DEPENDENCIES
   rspec-daemon
   rubocop (~> 1.88)
   rubocop-numbered-params
+  rubocop-rake
   steep
 
 BUNDLED WITH


### PR DESCRIPTION
Add the `rubocop-rake` plugin so this repository lints its Rake tasks, aligning it with the other repositories that already enable the full plugin set (numbered-params, rake, rbs_inline, rspec).

- Add `rubocop-rake` to the Gemfile and lockfile
- Register it under `plugins:` in `.rubocop.yml`

No new offenses are reported by `rubocop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)