### PR TITLE
Introduce rubocop-rbs_inline plugin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.2'
           - '3.3'
           - '3.4'
           - '4.0'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
 
 plugins:
   - rubocop-numbered-params

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,12 +4,22 @@ AllCops:
 plugins:
   - rubocop-numbered-params
   - rubocop-rake
+  - rubocop-rbs_inline
 
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true
 
 Style/Documentation:
   Enabled: false
+
+Style/RbsInline/MissingTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RedundantTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RequireRbsInlineComment:
+  EnforcedStyle: never
 
 Style/StringLiterals:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "rake", "~> 13.4"
 gem "rubocop", "~> 1.88"
 gem "rubocop-numbered-params"
 gem "rubocop-rake"
+gem "rubocop-rbs_inline"
 
 group :development do
   gem "rbs-inline", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,10 @@ GEM
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
+    rubocop-rbs_inline (1.5.5)
+      lint_roller (~> 1.1)
+      rbs-inline
+      rubocop (>= 1.72.1, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     steep (2.0.0)
@@ -145,6 +149,7 @@ DEPENDENCIES
   rubocop (~> 1.88)
   rubocop-numbered-params
   rubocop-rake
+  rubocop-rbs_inline
   steep
 
 BUNDLED WITH

--- a/lib/generators/rbs_config/install_generator.rb
+++ b/lib/generators/rbs_config/install_generator.rb
@@ -4,7 +4,7 @@ require "rails"
 
 module RbsConfig
   class InstallGenerator < Rails::Generators::Base
-    def create_raketask
+    def create_raketask #: void
       create_file "lib/tasks/rbs_config.rake", <<~RUBY
         begin
           # frozen_string_literal: true

--- a/rbs_config.gemspec
+++ b/rbs_config.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "A RBS files generator for Config gem"
   spec.homepage = "https://github.com/tk0miya/rbs_config"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 3.3.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/sig/generators/rbs_config/install_generator.rbs
+++ b/sig/generators/rbs_config/install_generator.rbs
@@ -2,6 +2,6 @@
 
 module RbsConfig
   class InstallGenerator < Rails::Generators::Base
-    def create_raketask: () -> untyped
+    def create_raketask: () -> void
   end
 end


### PR DESCRIPTION
Add the `rubocop-rbs_inline` plugin so this repository lints its RBS::Inline annotations, aligning it with the other repositories that already enable the full plugin set (numbered-params, rake, rbs_inline, rspec).

This PR contains two commits:

### Introduce rubocop-rbs_inline plugin
- Add `rubocop-rbs_inline` to the Gemfile and lockfile
- Register it under `plugins:` in `.rubocop.yml`
- Configure the `Style/RbsInline/*` cops with the same settings used across the sibling repositories (`doc_style_and_return_annotation`, `RequireRbsInlineComment: never`)
- Add the missing `#: void` return annotation on `InstallGenerator#create_raketask` flagged by the new cop, and regenerate the corresponding signature

### Drop Ruby 3.2 support
`rubocop-rbs_inline` requires Ruby >= 3.3, so drop 3.2 from the CI matrix, bump `required_ruby_version`, and raise `TargetRubyVersion` to 3.3.

`rubocop` reports no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)