### PR TITLE
Align .rubocop.yml with shared skeleton baseline

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,7 @@
+# NOTE: Rules are sorted in ASCII order.
+
 AllCops:
+  NewCops: enable
   TargetRubyVersion: 3.3
 
 plugins:
@@ -7,12 +10,45 @@ plugins:
   - rubocop-rbs_inline
   - rubocop-rspec
 
+# Layout
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true
+  AllowSteepAnnotation: true
 
-Style/Documentation:
+Layout/LineLength:
+  Max: 120
+
+# Metrics
+Metrics/AbcSize:
+  Max: 20
+
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*_spec.rb"
+
+Metrics/ClassLength:
+  Max: 200
+
+Metrics/MethodLength:
+  Max: 30
+
+# RSpec
+RSpec/ExampleLength:
   Enabled: false
 
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/NamedSubject:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Max: 5
+
+# RbsInline
 Style/RbsInline/MissingTypeAnnotation:
   EnforcedStyle: doc_style_and_return_annotation
 
@@ -22,23 +58,24 @@ Style/RbsInline/RedundantTypeAnnotation:
 Style/RbsInline/RequireRbsInlineComment:
   EnforcedStyle: never
 
+# Style
+Style/AccessorGrouping:
+  Enabled: false
+
+Style/CommentedKeyword:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: always
+
+Style/RedundantFormat:
+  Enabled: false
+
 Style/StringLiterals:
-  Enabled: true
   EnforcedStyle: double_quotes
 
 Style/StringLiteralsInInterpolation:
-  Enabled: true
   EnforcedStyle: double_quotes
-
-Layout/LineLength:
-  Max: 120
-
-Metrics/AbcSize:
-  Max: 20
-
-Metrics/BlockLength:
-  Exclude:
-    - "spec/**/*_spec.rb"
-
-Metrics/MethodLength:
-  Max: 20

--- a/lib/rbs_config/config.rb
+++ b/lib/rbs_config/config.rb
@@ -8,7 +8,7 @@ module RbsConfig
     # @rbs files: Array[Pathname]
     # @rbs class_name: String
     def self.generate(files:, class_name: "Settings") #: String
-      Generator.new(class_name: class_name, files: files).generate
+      Generator.new(class_name:, files:).generate
     end
 
     class Generator
@@ -47,7 +47,7 @@ module RbsConfig
       def format(rbs) #: String
         parsed = RBS::Parser.parse_signature(rbs)
         StringIO.new.tap do |out|
-          RBS::Writer.new(out: out).write(parsed[1] + parsed[2])
+          RBS::Writer.new(out:).write(parsed[1] + parsed[2])
         end.string
       end
 

--- a/lib/rbs_config/rails_config.rb
+++ b/lib/rbs_config/rails_config.rb
@@ -8,7 +8,7 @@ module RbsConfig
   module RailsConfig
     # @rbs mapping: Hash[untyped, Hash[untyped, untyped] | ActiveSupport::OrderedOptions]
     def self.generate(mapping:) #: String
-      Generator.new(mapping: mapping).generate
+      Generator.new(mapping:).generate
     end
 
     class Generator
@@ -45,7 +45,7 @@ module RbsConfig
       def format(rbs) #: String
         parsed = RBS::Parser.parse_signature(rbs)
         StringIO.new.tap do |out|
-          RBS::Writer.new(out: out).write(parsed[1] + parsed[2])
+          RBS::Writer.new(out:).write(parsed[1] + parsed[2])
         end.string
       end
 

--- a/lib/rbs_config/rake_task.rb
+++ b/lib/rbs_config/rake_task.rb
@@ -14,7 +14,7 @@ module RbsConfig
 
     # @rbs name: Symbol
     # @rbs &block: ?(RbsConfig::RakeTask) -> void
-    def initialize(name = :'rbs:config', &block) #: void
+    def initialize(name = :"rbs:config", &block) #: void
       super()
 
       @name = name
@@ -48,9 +48,9 @@ module RbsConfig
         signature_root_dir.mkpath
 
         rbs = if type == :config
-                RbsConfig::Config.generate(files: files, class_name: class_name)
+                RbsConfig::Config.generate(files:, class_name:)
               else
-                RbsConfig::RailsConfig.generate(mapping: mapping)
+                RbsConfig::RailsConfig.generate(mapping:)
               end
 
         signature_root_dir.join("#{class_name.underscore}.rbs").write(rbs)

--- a/rbs_config.gemspec
+++ b/rbs_config.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = spec.homepage
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|

--- a/spec/rbs_config/config_spec.rb
+++ b/spec/rbs_config/config_spec.rb
@@ -5,7 +5,7 @@ require "tempfile"
 
 RSpec.describe RbsConfig::Config do
   describe ".generate" do
-    subject { described_class.generate(files: files) }
+    subject { described_class.generate(files:) }
 
     let(:files) { [Pathname.new(config_file.path)] }
     let(:config_file) do

--- a/spec/rbs_config/rails_config_spec.rb
+++ b/spec/rbs_config/rails_config_spec.rb
@@ -5,7 +5,7 @@ require "tempfile"
 
 RSpec.describe RbsConfig::RailsConfig do
   describe ".generate" do
-    subject { described_class.generate(mapping: mapping) }
+    subject { described_class.generate(mapping:) }
 
     let(:mapping) do
       {


### PR DESCRIPTION
## Summary

Align this repository's `.rubocop.yml` with the shared `init-ruby-project`
skeleton so linting rules are consistent across all Ruby repositories, and
fix the offenses the aligned config surfaces.

## Config changes

- Fill in missing cops: `AllCops/NewCops`, `Layout/LeadingCommentSpace`
  `AllowSteepAnnotation`, `Metrics/ClassLength`, `RSpec/ExampleLength`,
  `RSpec/MultipleMemoizedHelpers`, `RSpec/MultipleExpectations`,
  `RSpec/NamedSubject`, `RSpec/NestedGroups`, `Style/AccessorGrouping`,
  `Style/CommentedKeyword`, `Style/HashSyntax`
- `Metrics/MethodLength`: 20 → 30 (match baseline)
- Rules sorted in ASCII order to match the skeleton

## Code changes (offenses surfaced by the new cops)

- Use `key:` value shorthand (`Style/HashSyntax`) and double-quoted symbols
- `rbs_config.gemspec`: set `rubygems_mfa_required`
- Disable `Style/RedundantFormat`: the local `format` method is not
  `Kernel#format`, so the cop is a false positive here

Verified locally with `rubocop` (no offenses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)