### PR TITLE
chore: sync .claude/hooks with the skills skeleton

### DIFF
--- a/.claude/hooks/protect-sig-files.sh
+++ b/.claude/hooks/protect-sig-files.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Prevents direct editing of auto-generated RBS type definition files.
-# Type definitions in */sig/ directories are managed by PostToolUse hooks.
+# Type definitions in the project's own sig/ are managed by PostToolUse hooks.
 # Hand-written stubs for third-party gems under sig/gems/ are exempt.
 
 # Hook input is JSON from stdin
@@ -11,11 +11,16 @@ tool_name=$(echo "$input" | jq -r '.tool_name // ""')
 if [[ "$tool_name" == "Write" || "$tool_name" == "Edit" ]]; then
     file_path=$(echo "$input" | jq -r '.tool_input.file_path // ""')
 
-    if [[ "$file_path" == */sig/gems/* || "$file_path" == sig/gems/* ]]; then
+    # Judge the path relative to the project root: only the sig/ there is
+    # generated. A sig/ nested elsewhere is hand-written and stays editable.
+    project_root="${CLAUDE_PROJECT_DIR:-$PWD}"
+    rel_path="${file_path#"${project_root}/"}"
+
+    if [[ "$rel_path" == sig/gems/* ]]; then
         exit 0
     fi
 
-    if [[ "$file_path" == */sig/* || "$file_path" == sig/* ]]; then
+    if [[ "$rel_path" == sig/* ]]; then
         echo "❌ ERROR: Direct editing of generated sig/ files is not allowed." >&2
         echo "📝 This repository's own types are generated: fix the inline RBS comments in the .rb file." >&2
         echo "💡 Hand-written files are allowed only under sig/gems/ (stubs for third-party gems)." >&2

--- a/.claude/hooks/self-review.sh
+++ b/.claude/hooks/self-review.sh
@@ -76,7 +76,17 @@ about to be committed BEFORE running git commit again:
 - Otherwise, run the bundled `/code-review` skill on the working diff.
 
 If the review finds issues, fix them and review again. Once it is clean, run the same
-git commit command again to proceed — it will be allowed through.'
+git commit command again to proceed — it will be allowed through.
+
+The review runs in an isolated subagent with no memory of earlier rounds, so it cannot
+tell on its own whether it is repeating itself — only you, the caller, have that history.
+Before fixing a finding, check your own conversation: if it asks for the same change as
+a finding you already attempted to satisfy twice before (worded differently still counts),
+and it is still not resolved, do not attempt a third fix. Instead stop and ask the user
+(AskUserQuestion): what the finding wants, how the two prior attempts addressed it, why it
+still was not accepted, and the options (try a different fix, skip this finding and
+commit, or decide the review point does not apply here). Do not run git commit again until
+the user answers — another round of fixes would only repeat the same mismatch.'
 
 jq -n --arg reason "$review_prompt" '{
   "hookSpecificOutput": {


### PR DESCRIPTION
Syncs the two hook scripts that drifted from the `tk0miya/skills` skeleton.

- `self-review.sh`: the review-fix cycle could loop forever when a finding and its fix kept talking past each other. The hook now tells the calling agent to stop after two failed attempts at the same point and consult the user instead of retrying a third time.
- `protect-sig-files.sh`: the hook matched `*/sig/*`, so it blocked edits to any file with a `sig/` component anywhere in its path. Paths are now resolved against the project root, so only the project's own generated `sig/` is protected and hand-written signatures nested under `lib/` stay editable.

The scripts are byte-identical to the skeleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)